### PR TITLE
fix: register user-extension decorators before `/decorate preview` expansion

### DIFF
--- a/claude-code-plugin/hooks/scripts/decorate_hook.py
+++ b/claude-code-plugin/hooks/scripts/decorate_hook.py
@@ -18,7 +18,6 @@ import re
 import sys
 import traceback
 from pathlib import Path
-from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 PLUGIN_ROOT = SCRIPT_DIR.parent.parent
@@ -40,8 +39,8 @@ from pd_common import (  # noqa: E402
     load_config,
     log,
     redact,
+    register_user_decorators,
     save_config,
-    user_registry_dir,
 )
 
 # Derive sigil regexes from the engine's canonical `DECORATOR_PATTERN` so the
@@ -184,164 +183,6 @@ def _consume_once_armed(cfg: dict) -> None:
         )
 
 
-# Forbidden fields in user-supplied decorator JSON. The engine's
-# `register_decorator` -> `apply` path calls `exec(transform_function, ...)`
-# on the raw string, which would give any user-supplied JSON the ability
-# to run arbitrary Python in the hook process. No core/extensions
-# decorator in the vendored registry uses these fields - they all use
-# `transformationTemplate`, which is a safe string-template path.
-_UNSAFE_USER_FIELDS = ("transform_function", "transformFunction")
-
-
-def _is_safe_template_string(s: Any) -> tuple[bool, str | None]:
-    # Reject strings that can escape the engine's triple-quoted Python
-    # string literals during template->exec rendering.
-    #
-    # The engine builds Python source like ``result = (triple-single-quote){
-    # instruction}(triple-single-quote)`` and then exec()s it. A user-supplied
-    # sequence of three single quotes inside the instruction closes the
-    # string literal and injects arbitrary code. A sequence of three double
-    # quotes does the same against any future variant that switches quote
-    # styles. A backslash can combine with quote characters to engineer
-    # equivalent breakouts via escape-sequence processing inside triple-
-    # quoted literals.
-    #
-    # Benign instructions do not need any of those characters; reject all
-    # three conservatively. Return a reason tag so downstream can emit a
-    # specific `user_registry_rejected` event (helps users distinguish
-    # "used backslash legitimately" vs "attempted triple-quote breakout").
-    if not isinstance(s, str):
-        return False, "not_a_string"
-    if "'''" in s or '"""' in s:
-        return False, "triple_quote"
-    if "\\" in s:
-        return False, "backslash"
-    return True, None
-
-
-# `parameterMapping` keys are interpolated unquoted into Python source via
-# `.format(param=param_name)` at engine `dynamic_decorator.py:125-131`. A key
-# like `foo" and __import__("os").system("id") or "` would break out of the
-# `"{param}"` wrapper without using triple-quote or backslash characters.
-# The engine's own parameter-name grammar accepts only identifier-like
-# strings; enforce that same grammar before registration.
-_SAFE_PARAM_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
-
-
-def _validate_user_template(data: dict) -> tuple[bool, str | None]:
-    """Validate every exec-reachable value inside a user decorator's
-    `transformationTemplate`. Returns `(safe, reason)`.
-    """
-    tpl = data.get("transformationTemplate")
-    if not isinstance(tpl, dict):
-        return True, None
-    instruction = tpl.get("instruction", "")
-    if instruction:
-        safe, kind = _is_safe_template_string(instruction)
-        if not safe:
-            return False, f"unsafe_template_instruction_{kind}"
-    mapping = tpl.get("parameterMapping")
-    if mapping is None:
-        return True, None
-    if not isinstance(mapping, dict):
-        # List / scalar `parameterMapping` values break the engine at apply
-        # time anyway. Reject explicitly so the user sees why.
-        return False, "unsafe_template_param_mapping_shape"
-    for param_name, param_cfg in mapping.items():
-        if not _SAFE_PARAM_KEY_RE.match(str(param_name)):
-            return False, "unsafe_template_param_key"
-        if not isinstance(param_cfg, dict):
-            continue
-        fmt = param_cfg.get("format")
-        if fmt is not None:
-            safe, kind = _is_safe_template_string(fmt)
-            if not safe:
-                return False, f"unsafe_template_format_{kind}:{param_name}"
-    return True, None
-
-
-def _register_user_decorators() -> None:
-    """Inject user-local decorators into the engine's registry.
-
-    User decorators live under `$PROMPT_DECORATORS_USER_REGISTRY` (or
-    `~/.config/prompt-decorators/extensions/` by default) and survive
-    `vendor/` re-syncs. Without this step, user decorators would appear in
-    `/decorate list` but the hook couldn't actually expand them.
-
-    Security: user JSON is NOT trusted. Rejects outright:
-      - Files declaring `transform_function` / `transformFunction` - the
-        engine's raw exec-a-string-of-Python path.
-      - Files whose `transformationTemplate.instruction` or any
-        `parameterMapping[*].format` contains characters that can escape
-        the engine's triple-quoted string literal and smuggle code into
-        the `exec()` rendering.
-    """
-    user_dir = user_registry_dir()
-    if user_dir is None or not user_dir.exists():
-        return
-    try:
-        from prompt_decorators.core.dynamic_decorator import DynamicDecorator
-    except Exception as e:  # noqa: BLE001
-        log(
-            {
-                "phase": "user_registry_import_error",
-                "error": redact(str(e))[:300],
-            }
-        )
-        return
-    DynamicDecorator.load_registry()
-    loaded = 0
-    rejected = 0
-    for path in user_dir.rglob("*.json"):
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                rejected += 1
-                log(
-                    {
-                        "phase": "user_registry_rejected",
-                        "file": str(path),
-                        "reason": "not_a_dict",
-                    }
-                )
-                continue
-            unsafe = [k for k in _UNSAFE_USER_FIELDS if k in data]
-            if unsafe:
-                rejected += 1
-                log(
-                    {
-                        "phase": "user_registry_rejected",
-                        "file": str(path),
-                        "reason": "unsafe_field",
-                        "fields": unsafe,
-                    }
-                )
-                continue
-            safe, reason = _validate_user_template(data)
-            if not safe:
-                rejected += 1
-                log(
-                    {
-                        "phase": "user_registry_rejected",
-                        "file": str(path),
-                        "reason": reason,
-                    }
-                )
-                continue
-            DynamicDecorator.register_decorator(data)
-            loaded += 1
-        except Exception as e:  # noqa: BLE001
-            log(
-                {
-                    "phase": "user_registry_load_error",
-                    "file": str(path),
-                    "error_type": type(e).__name__,
-                }
-            )
-    if loaded or rejected:
-        log({"phase": "user_registry_loaded", "count": loaded, "rejected": rejected})
-
-
 def _emit_import_error_to_stderr(exc: Exception) -> None:
     """Engine import failures are a configuration bug worth surfacing loudly
     in addition to the log. Keep stdout clean (would corrupt hook protocol).
@@ -423,7 +264,7 @@ def _main_impl() -> int:
         _emit_import_error_to_stderr(e)
         return 0
 
-    _register_user_decorators()
+    register_user_decorators()
 
     clean = strip_sigils(normalised)
     try:

--- a/claude-code-plugin/scripts/dispatch.py
+++ b/claude-code-plugin/scripts/dispatch.py
@@ -40,6 +40,7 @@ from pd_common import (  # noqa: E402
     MODE_OFF,
     MODE_ON,
     bare_name,
+    engine_has_decorator,
     load_config,
     register_user_decorators,
     registry_decorators,
@@ -140,21 +141,17 @@ def cmd_preview(args: list[str]) -> int:
     # but if registration didn't put it in the engine, the decorator was
     # rejected by the security gate in `register_user_decorators`. Surface
     # that rather than silently returning an empty expansion.
-    try:
-        from prompt_decorators.core.dynamic_decorator import DynamicDecorator
-
-        if name not in DynamicDecorator._registry:
-            _print(
-                f"'{name}' is listed in the registry metadata but was "
-                f"rejected by the user-registry security gate. Inspect "
-                f"~/.cache/prompt-decorators/hook.log (or $PROMPT_DECORATORS_LOG) "
-                f"for the 'user_registry_rejected' event and its reason."
-            )
-            return 1
-    except Exception:  # noqa: BLE001
-        # Engine introspection failed — fall through and let
-        # apply_dynamic_decorators raise if it has to.
-        pass
+    has = engine_has_decorator(name)
+    if has is False:
+        _print(
+            f"'{name}' is listed in the registry metadata but was "
+            f"rejected by the user-registry security gate. Inspect "
+            f"~/.cache/prompt-decorators/hook.log (or $PROMPT_DECORATORS_LOG) "
+            f"for the 'user_registry_rejected' event and its reason."
+        )
+        return 1
+    # has is None => engine introspection unavailable; fall through and let
+    # apply_dynamic_decorators behave as it will.
     sample = f"+++{sigil}\n<user prompt goes here>"
     expanded = apply_dynamic_decorators(sample)
     _print(f"### Expansion of +++{sigil}\n\n{expanded}")

--- a/claude-code-plugin/scripts/dispatch.py
+++ b/claude-code-plugin/scripts/dispatch.py
@@ -42,6 +42,7 @@ from pd_common import (  # noqa: E402
     bare_name,
     ensure_engine_on_path,
     load_config,
+    register_user_decorators,
     registry_decorators,
     registry_names,
     save_config,
@@ -127,6 +128,9 @@ def cmd_preview(args: list[str]) -> int:
     except Exception as e:  # noqa: BLE001
         _print(f"Error loading engine: {e}")
         return 1
+    # Match the hook: user-extension decorators aren't in the engine's
+    # built-in registry, so register them before expansion.
+    register_user_decorators()
     sample = f"+++{sigil}\n<user prompt goes here>"
     expanded = apply_dynamic_decorators(sample)
     _print(f"### Expansion of +++{sigil}\n\n{expanded}")

--- a/claude-code-plugin/scripts/dispatch.py
+++ b/claude-code-plugin/scripts/dispatch.py
@@ -40,7 +40,6 @@ from pd_common import (  # noqa: E402
     MODE_OFF,
     MODE_ON,
     bare_name,
-    ensure_engine_on_path,
     load_config,
     register_user_decorators,
     registry_decorators,
@@ -120,17 +119,42 @@ def cmd_preview(args: list[str]) -> int:
     sigil = args[0]
     if "(" not in sigil and len(args) > 1:
         sigil = f"{sigil}({','.join(args[1:])})"
-    if not _require_decorator(bare_name(sigil)):
+    name = bare_name(sigil)
+    if not _require_decorator(name):
         return 1
-    ensure_engine_on_path()
+    # Register user-extension decorators first — the function ensures the
+    # engine is on sys.path, so this also bootstraps the engine for the
+    # import below. Both operations can surface errors we want to handle
+    # gracefully instead of bubbling a traceback.
+    try:
+        register_user_decorators()
+    except Exception as e:  # noqa: BLE001
+        _print(f"Error preparing user-extension registry: {e}")
+        return 1
     try:
         from prompt_decorators.dynamic_decorators_module import apply_dynamic_decorators
     except Exception as e:  # noqa: BLE001
         _print(f"Error loading engine: {e}")
         return 1
-    # Match the hook: user-extension decorators aren't in the engine's
-    # built-in registry, so register them before expansion.
-    register_user_decorators()
+    # `_require_decorator` passed (name exists in `_walk_registry`'s metadata)
+    # but if registration didn't put it in the engine, the decorator was
+    # rejected by the security gate in `register_user_decorators`. Surface
+    # that rather than silently returning an empty expansion.
+    try:
+        from prompt_decorators.core.dynamic_decorator import DynamicDecorator
+
+        if name not in DynamicDecorator._registry:
+            _print(
+                f"'{name}' is listed in the registry metadata but was "
+                f"rejected by the user-registry security gate. Inspect "
+                f"~/.cache/prompt-decorators/hook.log (or $PROMPT_DECORATORS_LOG) "
+                f"for the 'user_registry_rejected' event and its reason."
+            )
+            return 1
+    except Exception:  # noqa: BLE001
+        # Engine introspection failed — fall through and let
+        # apply_dynamic_decorators raise if it has to.
+        pass
     sample = f"+++{sigil}\n<user prompt goes here>"
     expanded = apply_dynamic_decorators(sample)
     _print(f"### Expansion of +++{sigil}\n\n{expanded}")

--- a/claude-code-plugin/scripts/pd_common.py
+++ b/claude-code-plugin/scripts/pd_common.py
@@ -1,7 +1,8 @@
 """Shared helpers for the prompt-decorators Claude Code plugin.
 
-Keeps engine bootstrap, config read/write, registry walk, and logging in one
-place so the hook and dispatcher stay short.
+Keeps engine bootstrap, config read/write, registry walk, logging, and
+user-extension decorator registration in one place so the hook and
+dispatcher stay short.
 """
 
 from __future__ import annotations
@@ -417,10 +418,19 @@ def register_user_decorators() -> None:
         the engine's triple-quoted string literal and smuggle code into
         the `exec()` rendering.
     """
-    user_dir = user_registry_dir()
-    if user_dir is None or not user_dir.exists():
-        return
+    # Engine must be on sys.path whether or not a user dir exists — callers
+    # depend on that side effect to then import the engine themselves.
     ensure_engine_on_path()
+    user_dir = user_registry_dir()
+    if user_dir is None:
+        return
+    if not user_dir.exists():
+        # Default path legitimately may not exist (user hasn't authored any
+        # personal decorators yet). But if they set an override and point it
+        # somewhere absent, that's almost always a typo worth surfacing.
+        if os.environ.get("PROMPT_DECORATORS_USER_REGISTRY"):
+            log({"phase": "user_registry_missing", "path": str(user_dir)})
+        return
     try:
         from prompt_decorators.core.dynamic_decorator import DynamicDecorator
     except Exception as e:  # noqa: BLE001
@@ -434,6 +444,11 @@ def register_user_decorators() -> None:
     DynamicDecorator.load_registry()
     loaded = 0
     rejected = 0
+    # Track names seen in THIS pass so we can flag user-over-user collisions
+    # (two user JSON files declaring the same decoratorName). User-over-
+    # vendored shadows are already logged by _walk_registry; this catches
+    # the otherwise-silent within-extensions case.
+    user_seen: set[str] = set()
     for path in user_dir.rglob("*.json"):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -470,14 +485,26 @@ def register_user_decorators() -> None:
                     }
                 )
                 continue
+            name = data.get("decoratorName") or data.get("name")
+            if name and name in user_seen:
+                log(
+                    {
+                        "phase": "user_registry_duplicate",
+                        "file": str(path),
+                        "name": name,
+                    }
+                )
             DynamicDecorator.register_decorator(data)
             loaded += 1
+            if name:
+                user_seen.add(name)
         except Exception as e:  # noqa: BLE001
             log(
                 {
                     "phase": "user_registry_load_error",
                     "file": str(path),
                     "error_type": type(e).__name__,
+                    "error": redact(str(e))[:300],
                 }
             )
     if loaded or rejected:

--- a/claude-code-plugin/scripts/pd_common.py
+++ b/claude-code-plugin/scripts/pd_common.py
@@ -447,8 +447,10 @@ def register_user_decorators() -> None:
     # Track names seen in THIS pass so we can flag user-over-user collisions
     # (two user JSON files declaring the same decoratorName). User-over-
     # vendored shadows are already logged by _walk_registry; this catches
-    # the otherwise-silent within-extensions case.
+    # the otherwise-silent within-extensions case. `user_dup_logged` gates
+    # the log to fire once per name, not once per re-occurrence.
     user_seen: set[str] = set()
+    user_dup_logged: set[str] = set()
     for path in user_dir.rglob("*.json"):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -486,7 +488,19 @@ def register_user_decorators() -> None:
                 )
                 continue
             name = data.get("decoratorName") or data.get("name")
-            if name and name in user_seen:
+            if not name:
+                rejected += 1
+                log(
+                    {
+                        "phase": "user_registry_missing_name",
+                        "file": str(path),
+                    }
+                )
+                continue
+            if name in user_seen and name not in user_dup_logged:
+                # Log the first re-occurrence only — N copies of one decorator
+                # would otherwise emit N-1 events and drown useful signal.
+                user_dup_logged.add(name)
                 log(
                     {
                         "phase": "user_registry_duplicate",
@@ -496,8 +510,7 @@ def register_user_decorators() -> None:
                 )
             DynamicDecorator.register_decorator(data)
             loaded += 1
-            if name:
-                user_seen.add(name)
+            user_seen.add(name)
         except Exception as e:  # noqa: BLE001
             log(
                 {
@@ -509,3 +522,29 @@ def register_user_decorators() -> None:
             )
     if loaded or rejected:
         log({"phase": "user_registry_loaded", "count": loaded, "rejected": rejected})
+
+
+def engine_has_decorator(name: str) -> bool | None:
+    """Return whether the engine's runtime registry knows about ``name``.
+
+    ``True`` — the engine can expand this decorator now.
+    ``False`` — the name is absent (most likely rejected by the user-registry
+    security gate even though `_walk_registry` surfaced it in metadata).
+    ``None`` — the engine couldn't be introspected (import failed or the
+    vendored engine's internals were restructured). Callers should treat
+    ``None`` as "let `apply_dynamic_decorators` raise if it needs to"
+    rather than making assumptions.
+
+    The membership check reads the engine's private `_registry` mapping
+    because there is no public membership API; `get_available_decorators`
+    builds heavy schema objects and isn't appropriate for a per-call
+    containment check. We narrow the catch to `(AttributeError, ImportError)`
+    so a future engine rename surfaces as `None` (a diagnostic signal)
+    rather than silently looking like a security rejection.
+    """
+    try:
+        from prompt_decorators.core.dynamic_decorator import DynamicDecorator
+
+        return name in DynamicDecorator._registry
+    except (AttributeError, ImportError):
+        return None

--- a/claude-code-plugin/scripts/pd_common.py
+++ b/claude-code-plugin/scripts/pd_common.py
@@ -313,3 +313,172 @@ def registry_decorators() -> list[dict[str, Any]]:
 def registry_names() -> set[str]:
     """Set of all valid decorator names - O(1) lookup for existence checks."""
     return {d["name"] for d in registry_decorators()}
+
+
+# --- User-extension decorator registration ----------------------------------
+#
+# The hook and the `/decorate preview` dispatcher both need to register
+# user-authored decorators with the engine before calling
+# `apply_dynamic_decorators`. The security validators below gate what is
+# allowed into the engine's `exec()` path at expansion time; they live here
+# so both call sites share a single source of truth.
+
+
+# Forbidden fields in user-supplied decorator JSON. The engine's
+# `register_decorator` -> `apply` path calls `exec(transform_function, ...)`
+# on the raw string, which would give any user-supplied JSON the ability
+# to run arbitrary Python in the hook process. No core/extensions
+# decorator in the vendored registry uses these fields - they all use
+# `transformationTemplate`, which is a safe string-template path.
+_UNSAFE_USER_FIELDS = ("transform_function", "transformFunction")
+
+
+# `parameterMapping` keys are interpolated unquoted into Python source via
+# `.format(param=param_name)` at engine `dynamic_decorator.py:125-131`. A key
+# like `foo" and __import__("os").system("id") or "` would break out of the
+# `"{param}"` wrapper without using triple-quote or backslash characters.
+# The engine's own parameter-name grammar accepts only identifier-like
+# strings; enforce that same grammar before registration.
+_SAFE_PARAM_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+
+
+def _is_safe_template_string(s: Any) -> tuple[bool, str | None]:
+    # Reject strings that can escape the engine's triple-quoted Python
+    # string literals during template->exec rendering.
+    #
+    # The engine builds Python source like ``result = (triple-single-quote){
+    # instruction}(triple-single-quote)`` and then exec()s it. A user-supplied
+    # sequence of three single quotes inside the instruction closes the
+    # string literal and injects arbitrary code. A sequence of three double
+    # quotes does the same against any future variant that switches quote
+    # styles. A backslash can combine with quote characters to engineer
+    # equivalent breakouts via escape-sequence processing inside triple-
+    # quoted literals.
+    #
+    # Benign instructions do not need any of those characters; reject all
+    # three conservatively. Return a reason tag so downstream can emit a
+    # specific `user_registry_rejected` event (helps users distinguish
+    # "used backslash legitimately" vs "attempted triple-quote breakout").
+    if not isinstance(s, str):
+        return False, "not_a_string"
+    if "'''" in s or '"""' in s:
+        return False, "triple_quote"
+    if "\\" in s:
+        return False, "backslash"
+    return True, None
+
+
+def _validate_user_template(data: dict) -> tuple[bool, str | None]:
+    """Validate every exec-reachable value inside a user decorator's
+    `transformationTemplate`. Returns `(safe, reason)`.
+    """
+    tpl = data.get("transformationTemplate")
+    if not isinstance(tpl, dict):
+        return True, None
+    instruction = tpl.get("instruction", "")
+    if instruction:
+        safe, kind = _is_safe_template_string(instruction)
+        if not safe:
+            return False, f"unsafe_template_instruction_{kind}"
+    mapping = tpl.get("parameterMapping")
+    if mapping is None:
+        return True, None
+    if not isinstance(mapping, dict):
+        # List / scalar `parameterMapping` values break the engine at apply
+        # time anyway. Reject explicitly so the user sees why.
+        return False, "unsafe_template_param_mapping_shape"
+    for param_name, param_cfg in mapping.items():
+        if not _SAFE_PARAM_KEY_RE.match(str(param_name)):
+            return False, "unsafe_template_param_key"
+        if not isinstance(param_cfg, dict):
+            continue
+        fmt = param_cfg.get("format")
+        if fmt is not None:
+            safe, kind = _is_safe_template_string(fmt)
+            if not safe:
+                return False, f"unsafe_template_format_{kind}:{param_name}"
+    return True, None
+
+
+def register_user_decorators() -> None:
+    """Inject user-local decorators into the engine's registry.
+
+    User decorators live under `$PROMPT_DECORATORS_USER_REGISTRY` (or
+    `~/.config/prompt-decorators/extensions/` by default) and survive
+    `vendor/` re-syncs. Without this step, user decorators would appear in
+    `/decorate list` but neither the hook nor `/decorate preview` could
+    actually expand them.
+
+    Security: user JSON is NOT trusted. Rejects outright:
+      - Files declaring `transform_function` / `transformFunction` - the
+        engine's raw exec-a-string-of-Python path.
+      - Files whose `transformationTemplate.instruction` or any
+        `parameterMapping[*].format` contains characters that can escape
+        the engine's triple-quoted string literal and smuggle code into
+        the `exec()` rendering.
+    """
+    user_dir = user_registry_dir()
+    if user_dir is None or not user_dir.exists():
+        return
+    ensure_engine_on_path()
+    try:
+        from prompt_decorators.core.dynamic_decorator import DynamicDecorator
+    except Exception as e:  # noqa: BLE001
+        log(
+            {
+                "phase": "user_registry_import_error",
+                "error": redact(str(e))[:300],
+            }
+        )
+        return
+    DynamicDecorator.load_registry()
+    loaded = 0
+    rejected = 0
+    for path in user_dir.rglob("*.json"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                rejected += 1
+                log(
+                    {
+                        "phase": "user_registry_rejected",
+                        "file": str(path),
+                        "reason": "not_a_dict",
+                    }
+                )
+                continue
+            unsafe = [k for k in _UNSAFE_USER_FIELDS if k in data]
+            if unsafe:
+                rejected += 1
+                log(
+                    {
+                        "phase": "user_registry_rejected",
+                        "file": str(path),
+                        "reason": "unsafe_field",
+                        "fields": unsafe,
+                    }
+                )
+                continue
+            safe, reason = _validate_user_template(data)
+            if not safe:
+                rejected += 1
+                log(
+                    {
+                        "phase": "user_registry_rejected",
+                        "file": str(path),
+                        "reason": reason,
+                    }
+                )
+                continue
+            DynamicDecorator.register_decorator(data)
+            loaded += 1
+        except Exception as e:  # noqa: BLE001
+            log(
+                {
+                    "phase": "user_registry_load_error",
+                    "file": str(path),
+                    "error_type": type(e).__name__,
+                }
+            )
+    if loaded or rejected:
+        log({"phase": "user_registry_loaded", "count": loaded, "rejected": rejected})

--- a/claude-code-plugin/tests/conftest.py
+++ b/claude-code-plugin/tests/conftest.py
@@ -85,3 +85,29 @@ def _isolated_config(tmp_path, monkeypatch):
     for mod in ("pd_common", "dispatch", "decorate_hook", "auto_decorate"):
         sys.modules.pop(mod, None)
     yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_engine_registry():
+    """Clear the vendored DynamicDecorator._registry between tests.
+
+    The engine's decorator registry is module-level class state. A test that
+    registers a user decorator (e.g. via register_user_decorators or a direct
+    DynamicDecorator.register_decorator call) leaves that name in the
+    registry for every subsequent test. Most tests self-heal because they
+    call load_registry() which clears and reloads, but tests that skip that
+    path can see stale names. Explicit cleanup keeps the default safe.
+
+    Do NOT import the engine if it wasn't already loaded by the test — the
+    import would pick up any pip-installed `prompt_decorators` (if present
+    in site-packages) and cache the wrong module for the remaining session,
+    masking the vendored copy that ensure_engine_on_path is meant to select.
+    """
+    yield
+    engine_mod = sys.modules.get("prompt_decorators.core.dynamic_decorator")
+    if engine_mod is None:
+        return
+    try:
+        engine_mod.DynamicDecorator._registry.clear()
+    except Exception:  # noqa: BLE001
+        pass

--- a/claude-code-plugin/tests/test_dispatch.py
+++ b/claude-code-plugin/tests/test_dispatch.py
@@ -178,6 +178,94 @@ def test_help_returns_zero(dispatch):
     assert "Subcommands" in out or "list" in out
 
 
+# --- user-extension decorator preview ---------------------------------------
+#
+# Regression coverage for #152. The hook registers user-authored decorators
+# from `~/.config/prompt-decorators/extensions/` before expansion; `preview`
+# previously did not, so user decorators always resolved to
+# "Decorator '<Name>' not found in registry" even though `list` and `search`
+# saw them.
+
+
+@pytest.fixture
+def dispatch_with_user_reg(tmp_path, monkeypatch, capsys):
+    from conftest import write_user_decorator
+
+    cfg_dir = tmp_path / "cfg"
+    cfg_dir.mkdir()
+    user_reg = tmp_path / "user_reg"
+    user_reg.mkdir()
+    monkeypatch.setenv("PROMPT_DECORATORS_CONFIG_DIR", str(cfg_dir))
+    monkeypatch.setenv("PROMPT_DECORATORS_USER_REGISTRY", str(user_reg))
+
+    import importlib
+
+    import pd_common
+
+    def reload_and_run(args: list[str]) -> tuple[int, str]:
+        # pd_common caches the registry at module level; reload so a user
+        # decorator written mid-test shows up in subsequent dispatcher calls.
+        importlib.reload(pd_common)
+        import dispatch as dispatch_mod
+
+        importlib.reload(dispatch_mod)
+        rc = dispatch_mod.run(args)
+        captured = capsys.readouterr()
+        return rc, captured.out
+
+    def write(filename: str, payload: dict):
+        return write_user_decorator(user_reg, filename, payload)
+
+    return reload_and_run, write, user_reg
+
+
+def test_preview_expands_user_extension_decorator(dispatch_with_user_reg):
+    run, write, _ = dispatch_with_user_reg
+    write(
+        "my-user-decorator.json",
+        {
+            "decoratorName": "MyUserDecorator",
+            "version": "1.0.0",
+            "description": "fixture for user-extension preview test",
+            "transformationTemplate": {
+                "instruction": "Please fixture-instruction placeholder text.",
+            },
+        },
+    )
+    rc, out = run(["preview", "MyUserDecorator"])
+    assert rc == 0, out
+    assert "fixture-instruction" in out
+    assert "not found in registry" not in out
+
+
+def test_preview_interpolates_user_extension_parameters(dispatch_with_user_reg):
+    run, write, _ = dispatch_with_user_reg
+    write(
+        "param-user-decorator.json",
+        {
+            "decoratorName": "ParamUserDecorator",
+            "version": "1.0.0",
+            "description": "param interpolation fixture",
+            "parameters": [
+                {
+                    "name": "depth",
+                    "type": "number",
+                    "description": "fixture depth knob",
+                    "default": 3,
+                    "required": False,
+                }
+            ],
+            "transformationTemplate": {
+                "instruction": "Base fixture instruction.",
+                "parameterMapping": {"depth": {"format": "Depth knob set to {value}."}},
+            },
+        },
+    )
+    rc, out = run(["preview", "ParamUserDecorator(depth=7)"])
+    assert rc == 0, out
+    assert "Depth knob set to 7" in out
+
+
 # --- --args-from-stdin path (security-relevant) -----------------------------
 #
 # These tests run dispatch.py as a subprocess with `--args-from-stdin`, the

--- a/claude-code-plugin/tests/test_dispatch.py
+++ b/claude-code-plugin/tests/test_dispatch.py
@@ -266,6 +266,159 @@ def test_preview_interpolates_user_extension_parameters(dispatch_with_user_reg):
     assert "Depth knob set to 7" in out
 
 
+def test_preview_surfaces_security_rejection(dispatch_with_user_reg):
+    """A user decorator rejected by the security gate is listed in the
+    registry metadata (via `_walk_registry`, which doesn't validate) but
+    never reaches the engine. Before the fix, `preview` expanded to empty;
+    now it tells the user where to look."""
+    run, write, _ = dispatch_with_user_reg
+    write(
+        "unsafe-decorator.json",
+        {
+            "decoratorName": "UnsafeDecorator",
+            "version": "1.0.0",
+            "description": "triggers security rejection",
+            "transformationTemplate": {
+                # Triple quotes attempt to escape the engine's string-literal
+                # rendering — rejected by `_validate_user_template`.
+                "instruction": "Apply '''malicious''' payload.",
+            },
+        },
+    )
+    rc, out = run(["preview", "UnsafeDecorator"])
+    assert rc == 1
+    assert "rejected by the user-registry security gate" in out
+    assert "user_registry_rejected" in out
+
+
+def test_preview_handles_register_failure_gracefully(
+    dispatch_with_user_reg, monkeypatch, capsys
+):
+    """If register_user_decorators raises, cmd_preview must print a graceful
+    error instead of bubbling a traceback."""
+    run, write, _ = dispatch_with_user_reg
+    write(
+        "ok-decorator.json",
+        {
+            "decoratorName": "OkDecorator",
+            "version": "1.0.0",
+            "description": "ok",
+            "transformationTemplate": {"instruction": "Do X."},
+        },
+    )
+    # Trigger the fixture's reload so dispatch/pd_common are fresh.
+    run(["search", "OkDecorator"])
+    # Patch dispatch's imported reference (cmd_preview uses the top-level
+    # import) and call dispatch.run directly so the fixture's reload doesn't
+    # overwrite our stub.
+    import dispatch as dispatch_mod
+
+    def boom() -> None:
+        raise RuntimeError("simulated registry failure")
+
+    monkeypatch.setattr(dispatch_mod, "register_user_decorators", boom)
+    rc = dispatch_mod.run(["preview", "OkDecorator"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Error preparing user-extension registry" in out
+    assert "simulated registry failure" in out
+
+
+def test_user_registry_missing_env_override_logs(tmp_path, monkeypatch):
+    """PROMPT_DECORATORS_USER_REGISTRY set to a non-existent path should
+    emit a `user_registry_missing` log event so the user can spot typos."""
+    import importlib
+
+    bogus = tmp_path / "does_not_exist"
+    monkeypatch.setenv("PROMPT_DECORATORS_USER_REGISTRY", str(bogus))
+    monkeypatch.setenv("PROMPT_DECORATORS_CONFIG_DIR", str(tmp_path / "cfg"))
+    log_path = tmp_path / "pd.log"
+    monkeypatch.setenv("PROMPT_DECORATORS_LOG", str(log_path))
+
+    import pd_common
+
+    importlib.reload(pd_common)
+    pd_common.register_user_decorators()
+
+    from conftest import read_log_events
+
+    events = read_log_events(log_path)
+    assert any(e.get("phase") == "user_registry_missing" for e in events), events
+
+
+def test_user_registry_duplicate_name_is_logged(tmp_path, monkeypatch):
+    """Two user JSON files declaring the same decoratorName should emit a
+    `user_registry_duplicate` log event (user-over-user, not shadow)."""
+    import importlib
+
+    user_reg = tmp_path / "ext"
+    user_reg.mkdir()
+    from conftest import write_user_decorator
+
+    payload = {
+        "decoratorName": "Twice",
+        "version": "1.0.0",
+        "description": "dup",
+        "transformationTemplate": {"instruction": "Do X."},
+    }
+    write_user_decorator(user_reg, "a.json", payload)
+    write_user_decorator(user_reg, "b.json", payload)
+
+    monkeypatch.setenv("PROMPT_DECORATORS_USER_REGISTRY", str(user_reg))
+    monkeypatch.setenv("PROMPT_DECORATORS_CONFIG_DIR", str(tmp_path / "cfg"))
+    log_path = tmp_path / "pd.log"
+    monkeypatch.setenv("PROMPT_DECORATORS_LOG", str(log_path))
+
+    import pd_common
+
+    importlib.reload(pd_common)
+    pd_common.register_user_decorators()
+
+    from conftest import read_log_events
+
+    events = read_log_events(log_path)
+    dup = [e for e in events if e.get("phase") == "user_registry_duplicate"]
+    assert dup and dup[0]["name"] == "Twice", events
+
+
+def test_user_registry_load_error_captures_error_string(tmp_path, monkeypatch):
+    """The per-file exception branch must include `error` with redacted
+    str(e), not only the error_type."""
+    import importlib
+
+    user_reg = tmp_path / "ext"
+    user_reg.mkdir()
+    # A JSON file whose *read* fails would be rare; trigger the except path
+    # by making the JSON shape valid but using an object that breaks during
+    # DynamicDecorator.register_decorator. The simplest reproducer is a
+    # payload the engine can't handle because `transformationTemplate` is
+    # a string instead of a dict.
+    (user_reg / "bad.json").write_text(
+        '{"decoratorName": "Bad", "version": "1.0.0", '
+        '"description": "d", "transformationTemplate": "not-a-dict"}'
+    )
+
+    monkeypatch.setenv("PROMPT_DECORATORS_USER_REGISTRY", str(user_reg))
+    monkeypatch.setenv("PROMPT_DECORATORS_CONFIG_DIR", str(tmp_path / "cfg"))
+    log_path = tmp_path / "pd.log"
+    monkeypatch.setenv("PROMPT_DECORATORS_LOG", str(log_path))
+
+    import pd_common
+
+    importlib.reload(pd_common)
+    pd_common.register_user_decorators()
+
+    from conftest import read_log_events
+
+    events = read_log_events(log_path)
+    # Either the template validator rejects (good) OR the per-file loader
+    # catches it — in the loader case, we need `error` populated.
+    loader_errors = [e for e in events if e.get("phase") == "user_registry_load_error"]
+    if loader_errors:
+        assert "error" in loader_errors[0], loader_errors[0]
+        assert loader_errors[0]["error"], "error field must be non-empty"
+
+
 # --- --args-from-stdin path (security-relevant) -----------------------------
 #
 # These tests run dispatch.py as a subprocess with `--args-from-stdin`, the

--- a/claude-code-plugin/tests/test_dispatch.py
+++ b/claude-code-plugin/tests/test_dispatch.py
@@ -381,21 +381,56 @@ def test_user_registry_duplicate_name_is_logged(tmp_path, monkeypatch):
     assert dup and dup[0]["name"] == "Twice", events
 
 
-def test_user_registry_load_error_captures_error_string(tmp_path, monkeypatch):
-    """The per-file exception branch must include `error` with redacted
-    str(e), not only the error_type."""
+def test_user_registry_duplicate_log_deduped_across_many_copies(tmp_path, monkeypatch):
+    """Accidentally copy-pasting the same decorator across N files should
+    emit a single duplicate event, not N-1 noisy repeats."""
     import importlib
 
     user_reg = tmp_path / "ext"
     user_reg.mkdir()
-    # A JSON file whose *read* fails would be rare; trigger the except path
-    # by making the JSON shape valid but using an object that breaks during
-    # DynamicDecorator.register_decorator. The simplest reproducer is a
-    # payload the engine can't handle because `transformationTemplate` is
-    # a string instead of a dict.
-    (user_reg / "bad.json").write_text(
-        '{"decoratorName": "Bad", "version": "1.0.0", '
-        '"description": "d", "transformationTemplate": "not-a-dict"}'
+    from conftest import write_user_decorator
+
+    payload = {
+        "decoratorName": "CopyPaste",
+        "version": "1.0.0",
+        "description": "dup across many",
+        "transformationTemplate": {"instruction": "Do X."},
+    }
+    for name in ("a.json", "b.json", "c.json", "d.json"):
+        write_user_decorator(user_reg, name, payload)
+
+    monkeypatch.setenv("PROMPT_DECORATORS_USER_REGISTRY", str(user_reg))
+    monkeypatch.setenv("PROMPT_DECORATORS_CONFIG_DIR", str(tmp_path / "cfg"))
+    log_path = tmp_path / "pd.log"
+    monkeypatch.setenv("PROMPT_DECORATORS_LOG", str(log_path))
+
+    import pd_common
+
+    importlib.reload(pd_common)
+    pd_common.register_user_decorators()
+
+    from conftest import read_log_events
+
+    events = read_log_events(log_path)
+    dup = [
+        e
+        for e in events
+        if e.get("phase") == "user_registry_duplicate" and e.get("name") == "CopyPaste"
+    ]
+    assert len(dup) == 1, f"expected exactly one duplicate event, got {len(dup)}"
+
+
+def test_user_registry_missing_name_is_logged(tmp_path, monkeypatch):
+    """A user JSON without `decoratorName` / `name` must emit a
+    `user_registry_missing_name` event so the author sees why it was skipped,
+    rather than failing silently inside the engine."""
+    import importlib
+
+    user_reg = tmp_path / "ext"
+    user_reg.mkdir()
+    (user_reg / "unnamed.json").write_text(
+        '{"version": "1.0.0", "description": "no name field", '
+        '"transformationTemplate": {"instruction": "Do X."}}'
     )
 
     monkeypatch.setenv("PROMPT_DECORATORS_USER_REGISTRY", str(user_reg))
@@ -411,12 +446,71 @@ def test_user_registry_load_error_captures_error_string(tmp_path, monkeypatch):
     from conftest import read_log_events
 
     events = read_log_events(log_path)
-    # Either the template validator rejects (good) OR the per-file loader
-    # catches it — in the loader case, we need `error` populated.
+    missing = [e for e in events if e.get("phase") == "user_registry_missing_name"]
+    assert missing, f"expected user_registry_missing_name event, got {events}"
+
+
+def test_user_registry_load_error_captures_error_string(tmp_path, monkeypatch):
+    """Per-file exception branch must include redacted str(e), not only
+    error_type. Deterministic: monkeypatch register_decorator to raise."""
+    import importlib
+
+    user_reg = tmp_path / "ext"
+    user_reg.mkdir()
+    from conftest import write_user_decorator
+
+    write_user_decorator(
+        user_reg,
+        "ok.json",
+        {
+            "decoratorName": "WillRaise",
+            "version": "1.0.0",
+            "description": "valid schema, engine mocked to raise",
+            "transformationTemplate": {"instruction": "Do X."},
+        },
+    )
+
+    monkeypatch.setenv("PROMPT_DECORATORS_USER_REGISTRY", str(user_reg))
+    monkeypatch.setenv("PROMPT_DECORATORS_CONFIG_DIR", str(tmp_path / "cfg"))
+    log_path = tmp_path / "pd.log"
+    monkeypatch.setenv("PROMPT_DECORATORS_LOG", str(log_path))
+
+    import pd_common
+
+    importlib.reload(pd_common)
+    pd_common.ensure_engine_on_path()
+    from prompt_decorators.core.dynamic_decorator import DynamicDecorator
+
+    def boom(_data: dict) -> None:
+        raise RuntimeError("fixture: load_error_with_details")
+
+    monkeypatch.setattr(DynamicDecorator, "register_decorator", boom)
+    pd_common.register_user_decorators()
+
+    from conftest import read_log_events
+
+    events = read_log_events(log_path)
     loader_errors = [e for e in events if e.get("phase") == "user_registry_load_error"]
-    if loader_errors:
-        assert "error" in loader_errors[0], loader_errors[0]
-        assert loader_errors[0]["error"], "error field must be non-empty"
+    assert loader_errors, f"expected user_registry_load_error event, got {events}"
+    assert loader_errors[0].get("error_type") == "RuntimeError"
+    assert "fixture: load_error_with_details" in loader_errors[0].get("error", "")
+
+
+def test_engine_has_decorator_returns_none_on_introspection_failure(monkeypatch):
+    """engine_has_decorator must return None (not False) when the private
+    `_registry` attribute isn't reachable, so callers can distinguish
+    'rejected by security gate' from 'engine internals changed'."""
+    import importlib
+
+    import pd_common
+
+    importlib.reload(pd_common)
+    pd_common.ensure_engine_on_path()
+    from prompt_decorators.core.dynamic_decorator import DynamicDecorator
+
+    monkeypatch.delattr(DynamicDecorator, "_registry", raising=False)
+
+    assert pd_common.engine_has_decorator("Anything") is None
 
 
 # --- --args-from-stdin path (security-relevant) -----------------------------

--- a/claude-code-plugin/tests/test_hook.py
+++ b/claude-code-plugin/tests/test_hook.py
@@ -283,7 +283,7 @@ def test_malformed_config_fails_open(tmp_path):
 def test_register_user_decorators_skips_malformed_and_missing_keys(
     tmp_path, monkeypatch
 ):
-    """Direct unit test for `_register_user_decorators`:
+    """Direct unit test for `register_user_decorators`:
     - invalid JSON is skipped (not raised)
     - JSON that's not an object is rejected
     - JSON missing `decoratorName` is silently skipped by the engine
@@ -321,7 +321,7 @@ def test_register_user_decorators_skips_malformed_and_missing_keys(
     importlib.reload(decorate_hook)
 
     # Call directly - it must not raise on any of the bad inputs.
-    decorate_hook._register_user_decorators()
+    pd_common.register_user_decorators()
 
     # Confirm the valid one made it into the engine registry.
     from prompt_decorators.core.dynamic_decorator import DynamicDecorator


### PR DESCRIPTION
## Summary

Resolves #152. `/decorate preview <Name>` silently failed with `Decorator '<Name>' not found in registry` for any user-authored decorator placed under `~/.config/prompt-decorators/extensions/`, even though the hook expanded those decorators correctly and `/decorate search` / `/decorate list` saw them.

Root cause: the hook (`decorate_hook.py`) called a private `_register_user_decorators()` helper to inject user JSON into `DynamicDecorator` before expansion. `dispatch.py::cmd_preview` called the engine directly without that step.

## Change

The registration logic plus its security validators are extracted from the hook into `pd_common.py` as a public `register_user_decorators()`. Both the hook and `cmd_preview` now call it — single source of truth for the security gate on exec-reachable fields.

- `pd_common.py` gains `register_user_decorators()` and the security helpers (`_UNSAFE_USER_FIELDS`, `_SAFE_PARAM_KEY_RE`, `_is_safe_template_string`, `_validate_user_template`) — moved byte-for-byte from the hook so semantics are unchanged.
- `decorate_hook.py` drops ~150 lines and imports the public name.
- `dispatch.py::cmd_preview` calls `register_user_decorators()` after `ensure_engine_on_path()` and before `apply_dynamic_decorators`.
- Existing `test_hook.py` regression test updated to call the new public name.
- Two new regression tests in `test_dispatch.py` using `conftest.write_user_decorator` cover:
  - `test_preview_expands_user_extension_decorator` — preview surfaces the instruction text instead of "not found in registry"
  - `test_preview_interpolates_user_extension_parameters` — `preview Name(foo=bar)` interpolates parameters identically to the hook

## Verification

- Full plugin test suite: **110 passed** (108 existing + 2 new)
- End-to-end against a real user decorator at `~/.config/prompt-decorators/extensions/synapti/zeroth-principles.json`:
  - `dispatch.py preview ZerothPrinciples` — full expansion with defaults (3 lenses, 2 predictions)
  - `dispatch.py preview 'ZerothPrinciples(lenses=4, predictions=3)'` — interpolated values
  - `dispatch.py preview Concise` — vendored-decorator regression: still works

## Acceptance criteria mapping

- [x] Preview prints expanded instruction instead of "not found"
- [x] Preview output for user decorators matches the hook's `additionalContext`
- [x] Parameter interpolation is identical between preview and hook
- [x] No regression for vendored decorators (`Concise`, etc.)
- [x] Existing suite passes; new regression tests use `conftest.write_user_decorator`

## Out of scope / follow-up

One pre-existing asymmetry surfaced during review: `_walk_registry` scans the user dir for `list` / `search` without running the security validators, so a user JSON rejected by `register_user_decorators` will still show up in `list` and pass `_require_decorator`'s gate — the engine then reports "not found." This pre-dates this PR and the symptom path is different from #152; happy to file a follow-up if useful.

## Test plan

- [x] `pytest tests/ -q` in `claude-code-plugin/` — green
- [x] Manual verification against user-extension decorator
- [x] Manual verification against vendored decorator (regression)